### PR TITLE
Remove deprecated USE_L10N setting

### DIFF
--- a/printer/settings.py
+++ b/printer/settings.py
@@ -136,9 +136,8 @@ LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
 
+# Localized formatting relies on LANGUAGE_CODE and USE_I18N
 USE_I18N = True
-
-USE_L10N = True
 
 USE_TZ = True
 


### PR DESCRIPTION
## Summary
- drop USE_L10N, rely on USE_I18N and LANGUAGE_CODE for localization

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f5593c483309a841ee5964995d7