### PR TITLE
Specify default primary key field

### DIFF
--- a/printer/settings.py
+++ b/printer/settings.py
@@ -109,6 +109,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators


### PR DESCRIPTION
## Summary
- configure Django to use BigAutoField as the default primary key

## Testing
- ⚠️ `pip install -r requirements.txt` (failed: Could not find a version that satisfies the requirement asgiref==3.9.1)
- ⚠️ `python manage.py makemigrations` (failed: ModuleNotFoundError: No module named 'django')


------
https://chatgpt.com/codex/tasks/task_e_68c80f5d96c883309dcc1706afe52206