### PR TITLE
feat: update crispy forms to bootstrap5

### DIFF
--- a/printer/settings.py
+++ b/printer/settings.py
@@ -54,12 +54,14 @@ INSTALLED_APPS = [
 
     ## 3rd party ##
     'crispy_forms',
+    'crispy_bootstrap5',
 
     ## Programmer-defined ##
     'printer',
 ]
 
-CRISPY_TEMPLATE_PACK = 'bootstrap4' # For Crispy Forms
+CRISPY_ALLOWED_TEMPLATE_PACKS = ("bootstrap5",)
+CRISPY_TEMPLATE_PACK = 'bootstrap5'  # For Crispy Forms
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.9.1
 Django==5.2.6
-django-crispy-forms==2.4
+django-crispy-forms==2.5
+crispy-bootstrap5==0.7
 pytz==2025.2
 sqlparse==0.5.3


### PR DESCRIPTION
## Summary
- upgrade to django-crispy-forms 2.5 and add crispy-bootstrap5
- configure Bootstrap 5 template pack for crispy forms

## Testing
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c80f678f548330a40e8c777ca0e7c2