### PR TITLE
Fix settings form handling for Django 5

### DIFF
--- a/printer/models.py
+++ b/printer/models.py
@@ -39,13 +39,13 @@ class File(models.Model):
 
         super(File, self).save(*args, **kwargs)
 
-    def delete(self):
+    def delete(self, using=None, keep_parents=False):
         try:
             os.remove(f"{UPLOADS_DIR}{self.name}")
         except FileNotFoundError:
             pass
 
-        super(File, self).delete()
+        return super(File, self).delete(using=using, keep_parents=keep_parents)
 
     class Meta:
         verbose_name_plural = 'files'

--- a/printer/views.py
+++ b/printer/views.py
@@ -145,9 +145,12 @@ def edit_settings(request):
         else:
             form = SettingsForm(instance=app_settings, data=request.POST)
 
-        form.save()
-        file_printer.refresh_printer_profile()
-        return HttpResponseRedirect(reverse('index'))
+        if form.is_valid():
+            form.save()
+            file_printer.refresh_printer_profile()
+            return HttpResponseRedirect(reverse('index'))
+
+        messages.error(request, 'Please correct the errors below.')
 
     context = { 'settings': app_settings, 'form': form }
     return render(request, 'settings.html', context)

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -18,8 +18,9 @@
 			</div>
                         <div class="bg-white br-2 p-3 me-1 ms-1">
 				<div class="form-container">
-					<form method='post'>
-						{% crispy form %}
+                                        <form method='post'>
+                                                {% csrf_token %}
+                                                {% crispy form %}
 						<div class="d-flex justify-content-center p-3">
 							<button class="bttn-brand-blue" type="submit">Save</button>
                                                         <button class="bttn-danger ms-5" onclick="javascript:window.location.replace('/');">Cancel</button>

--- a/templates/upload_file.html
+++ b/templates/upload_file.html
@@ -18,8 +18,9 @@
 			</div>
                         <div class="bg-white br-2 p-3 me-1 ms-1">
 				<div class="form-container">
-					<form method='post' enctype='multipart/form-data'>
-						{% crispy form %}
+                                        <form method='post' enctype='multipart/form-data'>
+                                                {% csrf_token %}
+                                                {% crispy form %}
 						<div class="d-flex justify-content-center p-3">
 							<button class="bttn-brand-blue" type="submit">Save</button>
                                                         <button class="bttn-danger ms-5" onclick="javascript:window.location.replace('/');">Cancel</button>


### PR DESCRIPTION
## Summary
- update the File model delete override to respect Django's `using`/`keep_parents` arguments
- validate the settings form before saving so invalid data no longer raises errors
- include CSRF tokens in the upload and settings templates so POSTs succeed under Django 5

## Testing
- python manage.py check
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68c93c6bf8a483308f94c336014ab542