### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Compile Python files
+        run: python -m compileall printer manage.py
+
+      - name: Run Django checks
+        run: python manage.py check
+
+      - name: Run tests
+        run: python manage.py test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes to `main` and pull requests
- exercise the Django checks and test suite across Python 3.10–3.12
- compile project modules in CI to fail early on syntax errors

## Testing
- python manage.py check
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68c959518cc483308ce158df585b7a62