### PR TITLE
Improve systemd service configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,8 +146,9 @@ Setup
 
 
 | The repository includes a simple ``start.bash`` helper for Raspberry Pi
-| deployments. Update the IP address in that script to match your static
-| address before using it. You can then launch the server with:
+| deployments. Set the ``PRINTER_GUI_BIND_ADDRESS`` environment variable
+| to override the default bind address (``0.0.0.0:8000``) before using it,
+| if desired. You can then launch the server with:
 
 .. code:: bash
 
@@ -165,8 +166,18 @@ Setup
 | Assuming the server runs correctly, you may configure the
 | server to run automatically on startup as a systemd service.
 | On the Raspberry Pi, copy the 'printerserver.service' file
-| to '/etc/systemd/system/', update ``ExecStart`` if needed,
-| start it, and enable it.
+| to '/etc/systemd/system/', review the ``User``, ``Group``, and
+| ``WorkingDirectory`` directives, and adjust them if your
+| environment differs from the defaults. The service reads
+| optional overrides from ``/etc/default/printerserver``; you can
+| define ``PRINTER_GUI_BIND_ADDRESS`` there to change the bind
+| address without editing the unit file. For example:
+
+.. code:: bash
+
+    echo "PRINTER_GUI_BIND_ADDRESS=192.168.1.4:8000" | sudo tee /etc/default/printerserver
+
+| Start and enable it once it matches your setup.
 
 .. code:: bash
 

--- a/printerserver.service
+++ b/printerserver.service
@@ -1,9 +1,18 @@
 [Unit]
 Description=Django GUI printer web server
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-ExecStart=/home/pi/printer-gui/start.bash
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/printer-gui
+Environment=PRINTER_GUI_BIND_ADDRESS=0.0.0.0:8000
+EnvironmentFile=-/etc/default/printerserver
+ExecStart=/home/pi/printer-gui/venv/bin/python /home/pi/printer-gui/manage.py runserver $PRINTER_GUI_BIND_ADDRESS
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/start.bash
+++ b/start.bash
@@ -1,5 +1,16 @@
-#! /bin/bash -
+#!/usr/bin/env bash
 
-cd /home/pi/printer-gui
-source venv/bin/activate
-python3 manage.py runserver 192.168.1.4:8000
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_ROOT"
+
+if [[ -f "venv/bin/activate" ]]; then
+    # shellcheck disable=SC1091
+    source "venv/bin/activate"
+fi
+
+BIND_ADDRESS="${PRINTER_GUI_BIND_ADDRESS:-0.0.0.0:8000}"
+
+exec python3 manage.py runserver "$BIND_ADDRESS"
+


### PR DESCRIPTION
## Summary
- update the systemd unit to run the app from its virtualenv, wait for networking, and support environment overrides
- harden the helper start script so it detects its location, activates the venv when available, and respects PRINTER_GUI_BIND_ADDRESS
- document the new configuration knobs for systemd and the start script

## Testing
- python3 -m compileall printer

------
https://chatgpt.com/codex/tasks/task_e_68c96bc9b46c8330ab277d1ead9edcc0