### PR TITLE
Harden file printing command inputs

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -1,16 +1,17 @@
 from django.conf import settings as django_settings
 
 import subprocess as sp
-import os
 import re
+from pathlib import Path
+
 from .utils import DEFAULT_APP_SETTINGS, get_app_settings
 
 
-UPLOADS_DIR = django_settings.STATICFILES_DIRS[0] + '/uploads/'
+UPLOADS_DIR = Path(django_settings.STATICFILES_DIRS[0]) / 'uploads'
 DEFAULT_PRINTER_PROFILE = DEFAULT_APP_SETTINGS["printer_profile"]
 
-ALLOWED_COLORS = {"Gray", "RGB"}
-ALLOWED_ORIENTATIONS = {"3", "4"}
+COLOR_MODELS = {"Gray": "Gray", "RGB": "RGB"}
+ORIENTATION_OPTIONS = {"3": "3", "4": "4"}
 ALLOWED_PAGE_RANGES = {"0", "1"}
 _PRINTER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 _PAGE_SELECTION_PATTERN = re.compile(r"^[0-9]+(?:[-,][0-9]+)*$")
@@ -45,7 +46,48 @@ def refresh_printer_profile():
     _printer_profile = _load_printer_profile()
 
 
-def print_pdf(filename, page_range, pages, color, orientation):
+def _resolve_print_path(filename):
+    """Resolve and validate the path of an uploaded file."""
+
+    try:
+        candidate_path = Path(filename)
+    except (TypeError, ValueError):
+        return None, b"Invalid filename: must be a valid path"
+
+    uploads_root = UPLOADS_DIR.resolve()
+
+    if candidate_path.is_absolute():
+        normalized_path = candidate_path
+        base_name = candidate_path.name
+    else:
+        candidate_str = candidate_path.as_posix()
+        if candidate_path.name != candidate_str:
+            return None, b"Invalid filename: must not contain path separators"
+        normalized_path = uploads_root / candidate_str
+        base_name = candidate_str
+
+    if base_name.startswith('-'):
+        return None, b"Invalid filename: cannot start with '-'"
+
+    try:
+        resolved_path = normalized_path.resolve(strict=True)
+    except FileNotFoundError:
+        return None, b"Invalid filename: file does not exist"
+    except (OSError, RuntimeError):
+        return None, b"Invalid filename"
+
+    try:
+        resolved_path.relative_to(uploads_root)
+    except ValueError:
+        return None, b"Invalid filename: outside uploads directory"
+
+    if not resolved_path.is_file():
+        return None, b"Invalid filename: not a file"
+
+    return resolved_path, None
+
+
+def _execute_print_job(filename, page_range, pages, color, orientation):
     printer = _get_printer_profile()
     if not printer or printer == DEFAULT_PRINTER_PROFILE:
         error_message = "Printer profile is not configured.".encode()
@@ -54,10 +96,10 @@ def print_pdf(filename, page_range, pages, color, orientation):
     if not _PRINTER_NAME_PATTERN.fullmatch(printer):
         return b"", b"Invalid printer profile configured."
 
-    if color not in ALLOWED_COLORS:
+    if color not in COLOR_MODELS:
         return b"", b"Invalid color option requested."
 
-    if orientation not in ALLOWED_ORIENTATIONS:
+    if orientation not in ORIENTATION_OPTIONS:
         return b"", b"Invalid orientation option requested."
 
     if page_range not in ALLOWED_PAGE_RANGES:
@@ -68,36 +110,37 @@ def print_pdf(filename, page_range, pages, color, orientation):
         if not sanitized_pages or not _PAGE_SELECTION_PATTERN.fullmatch(sanitized_pages):
             return b"", b"Invalid page selection requested."
 
-    if page_range == '0':
-        command = [
-            'lp', '-d', printer, '-o',
-            ('orientation-requested=' + orientation),
-            '-o', ('ColorModel=' + color), filename
-        ]
-    else:
-        command = [
-            'lp', '-d', printer, '-P', sanitized_pages, '-o',
-            ('orientation-requested=' + orientation),
-            '-o', ('ColorModel=' + color), filename
-        ]
+    file_path, error = _resolve_print_path(filename)
+    if error is not None:
+        return b"", error
 
-    print_proc = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
-    output = print_proc.communicate()
-    
+    command = [
+        'lp', '-d', printer,
+        '-o', f'orientation-requested={ORIENTATION_OPTIONS[orientation]}',
+        '-o', f'ColorModel={COLOR_MODELS[color]}'
+    ]
+
+    if page_range != '0':
+        command.extend(['-P', sanitized_pages])
+
+    try:
+        with file_path.open('rb') as file_stream:
+            print_proc = sp.Popen(
+                command,
+                stdin=file_stream,
+                stdout=sp.PIPE,
+                stderr=sp.PIPE
+            )
+            output = print_proc.communicate()
+    except OSError:
+        return b"", b"Unable to access file for printing."
+
     return output
 
 
+def print_pdf(filename, page_range, pages, color, orientation):
+    return _execute_print_job(filename, page_range, pages, color, orientation)
+
+
 def print_file(filename, page_range, pages, color, orientation):
-    # Prevent filenames that could be interpreted as options or contain path traversal
-    if filename.startswith('-'):
-        return b"", b"Invalid filename: cannot start with '-'"
-    if os.path.basename(filename) != filename:
-        return b"", b"Invalid filename: must not contain path separators"
-    abs_path = os.path.abspath(os.path.join(UPLOADS_DIR, filename))
-    # Ensure the file is inside the uploads directory
-    if not abs_path.startswith(os.path.abspath(UPLOADS_DIR)):
-        return b"", b"Invalid filename: outside uploads directory"
-    # Optionally, check file existence
-    if not os.path.isfile(abs_path):
-        return b"", b"Invalid filename: file does not exist"
-    return print_pdf(abs_path, page_range, pages, color, orientation)
+    return _execute_print_job(filename, page_range, pages, color, orientation)


### PR DESCRIPTION
## Summary
- validate requested filenames with pathlib and ensure they point to real files inside the uploads directory
- build the lp command with sanitized options and stream file contents via stdin to avoid user-controlled arguments
- share the hardened execution path for both print_pdf and print_file helpers

## Testing
- python -m compileall printer/file_printer.py

------
https://chatgpt.com/codex/tasks/task_e_68ca58f80f2083308b8953a06721ce93