### PR TITLE
Harden file printer command handling

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -3,10 +3,13 @@ from django.conf import settings as django_settings
 import subprocess as sp
 import os
 import re
+from pathlib import Path
+from shutil import which
+
 from .utils import DEFAULT_APP_SETTINGS, get_app_settings
 
 
-UPLOADS_DIR = django_settings.STATICFILES_DIRS[0] + '/uploads/'
+UPLOADS_DIR = Path(django_settings.STATICFILES_DIRS[0]) / 'uploads'
 DEFAULT_PRINTER_PROFILE = DEFAULT_APP_SETTINGS["printer_profile"]
 
 ALLOWED_COLORS = {"Gray", "RGB"}
@@ -14,6 +17,9 @@ ALLOWED_ORIENTATIONS = {"3", "4"}
 ALLOWED_PAGE_RANGES = {"0", "1"}
 _PRINTER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 _PAGE_SELECTION_PATTERN = re.compile(r"^[0-9]+(?:[-,][0-9]+)*$")
+_SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_.\- ]+$")
+
+_LP_COMMAND = which("lp")
 
 
 _printer_profile = None
@@ -46,6 +52,14 @@ def refresh_printer_profile():
 
 
 def print_pdf(filename, page_range, pages, color, orientation):
+    if _LP_COMMAND is None:
+        return b"", b"Printing is unavailable: 'lp' command not found."
+
+    try:
+        filename_to_print = os.fspath(filename)
+    except TypeError:
+        return b"", b"Invalid filename provided for printing."
+
     printer = _get_printer_profile()
     if not printer or printer == DEFAULT_PRINTER_PROFILE:
         error_message = "Printer profile is not configured.".encode()
@@ -68,36 +82,59 @@ def print_pdf(filename, page_range, pages, color, orientation):
         if not sanitized_pages or not _PAGE_SELECTION_PATTERN.fullmatch(sanitized_pages):
             return b"", b"Invalid page selection requested."
 
+    if not os.path.isfile(filename_to_print):
+        return b"", b"File to print does not exist."
+
     if page_range == '0':
         command = [
-            'lp', '-d', printer, '-o',
+            _LP_COMMAND, '-d', printer, '-o',
             ('orientation-requested=' + orientation),
-            '-o', ('ColorModel=' + color), filename
+            '-o', ('ColorModel=' + color), filename_to_print
         ]
     else:
         command = [
-            'lp', '-d', printer, '-P', sanitized_pages, '-o',
+            _LP_COMMAND, '-d', printer, '-P', sanitized_pages, '-o',
             ('orientation-requested=' + orientation),
-            '-o', ('ColorModel=' + color), filename
+            '-o', ('ColorModel=' + color), filename_to_print
         ]
 
-    print_proc = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
-    output = print_proc.communicate()
-    
+    try:
+        print_proc = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
+        output = print_proc.communicate()
+    except OSError as exc:
+        return b"", f"Failed to execute print command: {exc}".encode()
+
     return output
 
 
 def print_file(filename, page_range, pages, color, orientation):
+    # Ensure filenames are non-empty plain strings to avoid surprises when
+    # building the command arguments.
+    if not isinstance(filename, str):
+        return b"", b"Invalid filename: must be a string"
+
+    sanitized_name = filename.strip()
+    if not sanitized_name:
+        return b"", b"Invalid filename: must not be empty"
+
     # Prevent filenames that could be interpreted as options or contain path traversal
-    if filename.startswith('-'):
+    if sanitized_name.startswith('-'):
         return b"", b"Invalid filename: cannot start with '-'"
-    if os.path.basename(filename) != filename:
-        return b"", b"Invalid filename: must not contain path separators"
-    abs_path = os.path.abspath(os.path.join(UPLOADS_DIR, filename))
-    # Ensure the file is inside the uploads directory
-    if not abs_path.startswith(os.path.abspath(UPLOADS_DIR)):
+    if not _SAFE_FILENAME_PATTERN.fullmatch(sanitized_name):
+        return b"", b"Invalid filename: contains unsupported characters"
+
+    uploads_dir_path = Path(UPLOADS_DIR)
+
+    try:
+        base_path = uploads_dir_path.resolve(strict=False)
+        candidate_path = (uploads_dir_path / sanitized_name).resolve(strict=False)
+    except (OSError, RuntimeError):
+        return b"", b"Invalid filename: path resolution failed"
+
+    if not candidate_path.is_relative_to(base_path):
         return b"", b"Invalid filename: outside uploads directory"
-    # Optionally, check file existence
-    if not os.path.isfile(abs_path):
+
+    if not candidate_path.is_file():
         return b"", b"Invalid filename: file does not exist"
-    return print_pdf(abs_path, page_range, pages, color, orientation)
+
+    return print_pdf(candidate_path, page_range, pages, color, orientation)


### PR DESCRIPTION
## Summary
- tighten validation around filenames and ensure uploaded files stay within the uploads directory
- use the resolved `lp` binary, validate the file exists, and surface clearer errors before running the command
- handle failures when invoking the print process so callers receive safe error messages

## Testing
- python -m compileall printer/file_printer.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5ddc706c8330a882ae2f92523219