### PR TITLE
Add strict filename validation before printing

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -14,6 +14,7 @@ ALLOWED_ORIENTATIONS = {"3", "4"}
 ALLOWED_PAGE_RANGES = {"0", "1"}
 _PRINTER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 _PAGE_SELECTION_PATTERN = re.compile(r"^[0-9]+(?:[-,][0-9]+)*$")
+_SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 _printer_profile = None
@@ -93,6 +94,8 @@ def print_file(filename, page_range, pages, color, orientation):
         return b"", b"Invalid filename: cannot start with '-'"
     if os.path.basename(filename) != filename:
         return b"", b"Invalid filename: must not contain path separators"
+    if not _SAFE_FILENAME_PATTERN.fullmatch(filename):
+        return b"", b"Invalid filename: contains unsafe characters"
     abs_path = os.path.abspath(os.path.join(UPLOADS_DIR, filename))
     # Ensure the file is inside the uploads directory
     if not abs_path.startswith(os.path.abspath(UPLOADS_DIR)):


### PR DESCRIPTION
## Summary
- add a regular expression to strictly limit filenames accepted for printing
- reject filenames containing unsafe characters before resolving upload paths

## Testing
- python -m compileall printer

------
https://chatgpt.com/codex/tasks/task_e_68ca6bb0162c833090177980c9db138f