### PR TITLE
Harden printer profile handling against command injection

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -3,6 +3,8 @@ from django.conf import settings as django_settings
 import subprocess as sp
 import os
 import re
+from typing import List, Optional, Tuple
+
 from .utils import DEFAULT_APP_SETTINGS, get_app_settings
 
 
@@ -18,6 +20,66 @@ _SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 _printer_profile = None
+_PRINTER_QUERY_TIMEOUT = 5
+
+
+def sanitize_printer_name(printer_name: Optional[str]) -> Optional[str]:
+    """Return a safe printer name or ``None`` if the value is unsafe."""
+
+    if printer_name is None:
+        return None
+
+    sanitized = printer_name.strip()
+    if not sanitized or sanitized == DEFAULT_PRINTER_PROFILE:
+        return None
+
+    if not _PRINTER_NAME_PATTERN.fullmatch(sanitized):
+        return None
+
+    if sanitized.startswith('-'):
+        return None
+
+    return sanitized
+
+
+def _collect_available_printers() -> List[str]:
+    """Return a list of sanitized printer names reported by CUPS."""
+
+    try:
+        result = sp.run(
+            ['lpstat', '-a'],
+            check=False,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            text=True,
+            timeout=_PRINTER_QUERY_TIMEOUT,
+        )
+    except (OSError, ValueError, sp.TimeoutExpired):
+        return []
+
+    printers: List[str] = []
+    for line in result.stdout.splitlines():
+        candidate = line.split(' accepting', 1)[0].strip()
+        sanitized = sanitize_printer_name(candidate)
+        if sanitized and sanitized not in printers:
+            printers.append(sanitized)
+
+    return printers
+
+
+def get_available_printer_profiles(current_selection: Optional[str] = None) -> List[Tuple[str, str]]:
+    """Return choices for printer profiles, including the current selection if needed."""
+
+    printers = _collect_available_printers()
+    current = sanitize_printer_name(current_selection)
+
+    if current and current not in printers:
+        printers.insert(0, current)
+
+    if not printers:
+        return [(DEFAULT_PRINTER_PROFILE, DEFAULT_PRINTER_PROFILE)]
+
+    return [(printer, printer) for printer in printers]
 
 
 def _load_printer_profile():
@@ -26,9 +88,14 @@ def _load_printer_profile():
         return DEFAULT_PRINTER_PROFILE
 
     app_settings.refresh_from_db()
-    printer_name = app_settings.printer_profile
-    if not printer_name:
+    printer_name = sanitize_printer_name(app_settings.printer_profile)
+    if printer_name is None:
         return DEFAULT_PRINTER_PROFILE
+
+    available_printers = set(_collect_available_printers())
+    if available_printers and printer_name not in available_printers:
+        return DEFAULT_PRINTER_PROFILE
+
     return printer_name
 
 
@@ -52,7 +119,8 @@ def print_pdf(filename, page_range, pages, color, orientation):
         error_message = "Printer profile is not configured.".encode()
         return b"", error_message
 
-    if not _PRINTER_NAME_PATTERN.fullmatch(printer):
+    printer = sanitize_printer_name(printer)
+    if printer is None:
         return b"", b"Invalid printer profile configured."
 
     if color not in ALLOWED_COLORS:

--- a/printer/forms.py
+++ b/printer/forms.py
@@ -1,29 +1,10 @@
 from django import forms
 from .models import *
-import subprocess
+
+from .file_printer import get_available_printer_profiles
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Row, Column
-
-# Get available printer profiles:
-available_printer_profiles = [] # List of tuples for available printer profiles
-try:
-    proc = subprocess.Popen(['lpstat', '-a'], shell=False,
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-    stdout = proc.communicate()[0].decode('utf-8')
-    stdout_list = stdout.split('\n')
-    list_len = len(stdout_list)
-    stdout_list.remove(stdout_list[(list_len - 1)]) # Remove blank element at end.
-
-    for i in range(0, (list_len - 1)):
-        stdout_list[i] = stdout_list[i].split(' accepting')[0]
-
-    for profile in stdout_list:
-        available_printer_profiles.append((profile, profile))
-except:
-    available_printer_profiles.append(('None found', 'None found'))
-
 
 class PrintOptions:
     RANGE_OPTIONS = (
@@ -76,11 +57,9 @@ class SettingsForm(forms.ModelForm):
             choices=PrintOptions.ORIENTATION_OPTIONS
         )
     )
-    printer_profile = forms.CharField(
+    printer_profile = forms.ChoiceField(
         label='Printer Profile',
-        widget=forms.Select(
-            choices=available_printer_profiles
-        )
+        choices=(),
     )
 
     class Meta:
@@ -90,6 +69,8 @@ class SettingsForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        current_selection = self.initial.get('printer_profile') or getattr(self.instance, 'printer_profile', None)
+        self.fields['printer_profile'].choices = get_available_printer_profiles(current_selection)
         self.helper = FormHelper()
         self.helper.form_class='form-horizontal'
         self.helper.label_class='col-25 fs-400 ff-sans-normal'


### PR DESCRIPTION
## Summary
- add reusable sanitization helpers to filter printer names from CUPS and reject unsafe printer profiles before executing lp
- update the settings form to source printer choices from the sanitized allowlist so only vetted printer profiles can be saved

## Testing
- python -m compileall printer
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ca6f82c2388330b80547ca990983e7