### PR TITLE
Load Django secret key from environment

### DIFF
--- a/printer/settings.py
+++ b/printer/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 from django.contrib.messages import constants as messages_constants
+from django.core.management.utils import get_random_secret_key
 
 import os
 
@@ -31,7 +32,9 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'wo8w8mup4ocubo%dglvr814!2jg#nj3y*1h0m%qdch=aj67rui'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    SECRET_KEY = get_random_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- load the Django SECRET_KEY from the DJANGO_SECRET_KEY environment variable
- fall back to generating a random secret key at runtime instead of using a hard-coded value

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ca8ba099e483308c0337d31c6ccc09