### PR TITLE
Improve allowed host normalization and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,10 +116,15 @@ Setup
       static routers=192.168.1.1
 
 
-6) Add your IP address in printer/settings.py
----------------------------------------------
-| Open the settings.py file and enter your server's IP address as
-| a string in the ALLOWED_HOSTS list.
+6) Configure allowed hosts
+--------------------------
+| The server automatically allows loopback requests and adds the host
+| from ``PRINTER_GUI_BIND_ADDRESS`` (``0.0.0.0:8000`` by default) when
+| it names a specific interface. Set ``PRINTER_GUI_BIND_ADDRESS`` to
+| your static IP (or hostname) so it is added automatically, or leave
+| it unspecified and list additional names in ``PRINTER_GUI_ALLOWED_HOSTS``
+| as a comma-separated list. Use the bracketed form for IPv6 entries
+| (e.g. ``[2001:db8::1]`` or ``[fe80::1%wlan0]``).
 
 
 7) Start the development server
@@ -159,11 +164,13 @@ Setup
 | environment differs from the defaults. The service reads
 | optional overrides from ``/etc/default/printerserver``; you can
 | define ``PRINTER_GUI_BIND_ADDRESS`` there to change the bind
-| address without editing the unit file. For example:
+| address and ``PRINTER_GUI_ALLOWED_HOSTS`` to permit additional
+| hostnames without editing the unit file. For example:
 
 .. code:: bash
 
     echo "PRINTER_GUI_BIND_ADDRESS=192.168.1.4:8000" | sudo tee /etc/default/printerserver
+    echo "PRINTER_GUI_ALLOWED_HOSTS=printer.example.com,printer.local" | sudo tee -a /etc/default/printerserver
 
 | Start and enable it once it matches your setup.
 


### PR DESCRIPTION
## Summary
- normalize allowed host parsing so the bind address and extra environment entries handle IPv4, IPv6 (including zone identifiers), and hostnames consistently
- deduplicate and validate the dynamically built `ALLOWED_HOSTS` list while skipping unspecified bind addresses
- document the updated allowed-host configuration workflow and note the bracketed IPv6 syntax in the deployment guide

## Testing
- python -m compileall printer/settings.py

------
https://chatgpt.com/codex/tasks/task_e_68ca9b577210833090a2036a0673afc9