### PR TITLE
Improve upload handling and queue operations

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -1,15 +1,13 @@
-from django.conf import settings as django_settings
-
-import subprocess as sp
 import os
+import subprocess as sp
 import re
 from typing import List, Optional, Tuple
 
+from .paths import UPLOADS_DIR
 from .utils import DEFAULT_APP_SETTINGS, get_app_settings
 
 
-UPLOADS_DIR = django_settings.STATICFILES_DIRS[0] + '/uploads/'
-UPLOADS_ROOT = os.path.abspath(UPLOADS_DIR)
+UPLOADS_ROOT = os.path.abspath(str(UPLOADS_DIR))
 DEFAULT_PRINTER_PROFILE = DEFAULT_APP_SETTINGS["printer_profile"]
 
 ALLOWED_COLORS = {"Gray", "RGB"}

--- a/printer/models.py
+++ b/printer/models.py
@@ -1,10 +1,8 @@
 from django.db import models
-from . import settings
 
-import os
+from pathlib import Path
 
-
-UPLOADS_DIR = settings.STATICFILES_DIRS[0] + '/uploads/'
+from .paths import UPLOADS_DIR
 
 
 class File(models.Model):
@@ -16,23 +14,21 @@ class File(models.Model):
     orientation = models.CharField(max_length=1)
     file_type = models.CharField(max_length=20)
 
+    _FILE_TYPE_LABELS = {
+        '.pdf': 'PDF',
+        '.ps': 'PostScript',
+        '.txt': 'Plain text',
+        '.jpg': 'JPEG image',
+        '.jpeg': 'JPEG image',
+        '.png': 'PNG image',
+        '.gif': 'GIF image',
+        '.tif': 'TIFF image',
+        '.tiff': 'TIFF image',
+    }
+
     def determine_file_type(self, filename):
-        if filename.endswith('pdf'):
-            self.file_type = 'PDF'
-        elif filename.endswith('ps'):
-            self.file_type = 'PostScript'
-        elif filename.endswith('txt'):
-            self.file_type = 'Plain text'
-        elif filename.endswith('jpg') or filename.endswith('jpeg'):
-            self.file_type = 'JPEG image'
-        elif filename.endswith('png'):
-            self.file_type = 'PNG image'
-        elif filename.endswith('gif'):
-            self.file_type = 'GIF image'
-        elif filename.endswith('tif') or filename.endswith('tiff'):
-            self.file_type = 'TIFF image'
-        else:
-            self.file_type = 'Unknown format'
+        suffix = Path(filename).suffix.lower()
+        self.file_type = self._FILE_TYPE_LABELS.get(suffix, 'Unknown format')
 
     def save(self, *args, **kwargs):
         self.determine_file_type(self.name.lower())
@@ -41,8 +37,10 @@ class File(models.Model):
 
     def delete(self, using=None, keep_parents=False):
         try:
-            os.remove(f"{UPLOADS_DIR}{self.name}")
+            (UPLOADS_DIR / self.name).unlink()
         except FileNotFoundError:
+            pass
+        except OSError:
             pass
 
         return super(File, self).delete(using=using, keep_parents=keep_parents)

--- a/printer/paths.py
+++ b/printer/paths.py
@@ -1,0 +1,22 @@
+"""Shared filesystem paths used by the printer application."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings as django_settings
+
+
+# ``STATICFILES_DIRS`` is configured in ``printer.settings`` to point at the
+# project level ``static`` directory.  All uploaded files live inside an
+# ``uploads`` folder beneath this directory so that they can be served and
+# cleaned up consistently regardless of which module is interacting with them.
+UPLOADS_DIR = Path(django_settings.STATICFILES_DIRS[0]) / "uploads"
+
+
+def ensure_uploads_dir_exists() -> Path:
+    """Ensure the uploads directory exists before we attempt to use it."""
+
+    UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    return UPLOADS_DIR
+

--- a/printer/urls.py
+++ b/printer/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path('upload_file', views.upload_file, name='upload_file'),
     path('edit_file/<int:file_id>/', views.edit_file, name='edit_file'),
     path('submit_edit_file_form/', views.submit_edit_file_form, name='submit_edit_file_form'),
-    path('delete_file<int:file_id>/', views.delete_file, name='delete_file'),
+    path('delete_file/<int:file_id>/', views.delete_file, name='delete_file'),
     path('print_files/', views.print_files, name='print_files'),
     path('settings', views.edit_settings, name='settings'),
 ]

--- a/printer/views.py
+++ b/printer/views.py
@@ -1,37 +1,46 @@
 from django.contrib import messages
-from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.core.files.storage import FileSystemStorage
 from django.views.decorators.cache import never_cache
-from django.conf import settings as django_settings
-
-from .models import *
-from .forms import *
-from . import file_printer
-from .utils import DEFAULT_APP_SETTINGS, get_app_settings
+from django.views.decorators.http import require_POST
 
 import re
 from pathlib import Path
+
+from . import file_printer
+from .forms import FileUploadForm, PrintOptions, SettingsForm
+from .models import File
+from .paths import UPLOADS_DIR, ensure_uploads_dir_exists
+from .utils import DEFAULT_APP_SETTINGS, get_app_settings
 
 ALLOWED_EXTENSIONS = {
     '.pdf', '.ps', '.txt', '.jpg', '.jpeg', '.png', '.gif', '.tif', '.tiff'
 }
 
 
-UPLOADS_DIR = django_settings.STATICFILES_DIRS[0] + '/uploads/'
+def _sanitize_upload_name(upload_name: str) -> str:
+    """Return a filesystem-safe filename that preserves the original suffix."""
+
+    candidate = Path(upload_name)
+    sanitized_stem = re.sub(r'[^A-Za-z0-9_-]+', '-', candidate.stem).strip('-_')
+    if not sanitized_stem:
+        sanitized_stem = 'upload'
+    return f"{sanitized_stem}{candidate.suffix.lower()}"
 
 
 @never_cache
 def index(request):
-    files = File.objects.all()
-    context = { 'files': files }
+    files = File.objects.order_by('-uploaded_at')
+    context = {'files': files}
     return render(request, 'index.html', context)
 
 
 def upload_file(request):
     printer_selected = True
     app_settings = get_app_settings()
+    form = FileUploadForm()
 
     if request.method != 'POST':
         if app_settings is not None:
@@ -40,19 +49,18 @@ def upload_file(request):
                 printer_selected = False
         else:
             printer_selected = False
-
-        form = FileUploadForm()
     else:
-        fs_storage = FileSystemStorage(location=UPLOADS_DIR)
-        upload = request.FILES['file_upload']
+        upload = request.FILES.get('file_upload')
+        if upload is None:
+            messages.error(request, 'No file was selected for upload.')
+            return HttpResponseRedirect(reverse('index'))
 
         ext = Path(upload.name).suffix.lower()
         if ext not in ALLOWED_EXTENSIONS:
             messages.error(request, 'File type not supported')
             return HttpResponseRedirect(reverse('index'))
 
-        filename = re.sub('[^a-zA-Z0-9.]', '-', upload.name)
-        upload.name = filename
+        upload.name = _sanitize_upload_name(upload.name)
 
         # Get settings object to apply defaults to the new file object:
         default_color = DEFAULT_APP_SETTINGS['default_color']
@@ -63,70 +71,126 @@ def upload_file(request):
             default_color = app_settings.default_color or default_color
             default_orientation = app_settings.default_orientation or default_orientation
 
-        filename = fs_storage.save(filename, upload)
-        new_file = File(
-            name=upload.name, page_range='0', pages='All',
+        ensure_uploads_dir_exists()
+        storage = FileSystemStorage(location=str(UPLOADS_DIR))
+
+        try:
+            saved_name = storage.save(upload.name, upload)
+        except Exception:
+            messages.error(request, 'An unexpected error occurred while saving the file. Please try again.')
+            return HttpResponseRedirect(reverse('index'))
+
+        File.objects.create(
+            name=saved_name,
+            page_range='0',
+            pages='All',
             color=default_color,
-            orientation=default_orientation
+            orientation=default_orientation,
         )
-        new_file.save()
+        messages.success(request, f'Queued {saved_name} for printing.')
         return HttpResponseRedirect(reverse('index'))
 
-    context = { 'printer_selected': printer_selected, 'form': form }
+    context = {'printer_selected': printer_selected, 'form': form}
     return render(request, 'upload_file.html', context)
 
 
 def edit_file(request, file_id):
-    fileObj = File.objects.get(id=file_id)
-    fileObj.refresh_from_db()
-    context = { 'file': fileObj }
+    file_obj = get_object_or_404(File, id=file_id)
+    file_obj.refresh_from_db()
+    context = {'file': file_obj}
     return render(request, 'edit_file.html', context)
 
 
+@require_POST
 def submit_edit_file_form(request):
-    if request.method == 'POST':
-        fileObj = File.objects.get(id=int(request.POST['file_id']))
-        fileObj.name = request.POST['name']
-        fileObj.page_range = request.POST['page_range']
-        fileObj.pages = request.POST['pages']
-        fileObj.color = request.POST['color']
-        fileObj.orientation = request.POST['orientation']
-        fileObj.save()
-        return HttpResponse(status=200)
+    try:
+        file_id = int(request.POST.get('file_id', ''))
+    except (TypeError, ValueError):
+        return HttpResponse(status=400)
+
+    file_obj = get_object_or_404(File, id=file_id)
+
+    page_range = request.POST.get('page_range', '').strip()
+    pages = request.POST.get('pages', '').strip()
+    color = request.POST.get('color', '').strip()
+    orientation = request.POST.get('orientation', '').strip()
+
+    valid_page_ranges = {choice for choice, _ in PrintOptions.RANGE_OPTIONS}
+    valid_colors = {choice for choice, _ in PrintOptions.COLOR_OPTIONS}
+    valid_orientations = {choice for choice, _ in PrintOptions.ORIENTATION_OPTIONS}
+
+    if (
+        page_range not in valid_page_ranges
+        or color not in valid_colors
+        or orientation not in valid_orientations
+    ):
+        return HttpResponse(status=400)
+
+    if page_range == '0':
+        pages_value = 'All'
     else:
-        return HttpResponse(status=403)
+        pages_value = pages or '1-1'
+
+    file_obj.page_range = page_range
+    file_obj.pages = pages_value
+    file_obj.color = color
+    file_obj.orientation = orientation
+    file_obj.save(update_fields=['page_range', 'pages', 'color', 'orientation'])
+    return HttpResponse(status=200)
 
 
+@require_POST
 def delete_file(request, file_id):
-    fileObj = File.objects.get(id=file_id)
-    fileObj.delete()
-    
+    file_obj = get_object_or_404(File, id=file_id)
+    file_name = file_obj.name
+    file_obj.delete()
+    messages.success(request, f'Removed {file_name} from the queue.')
+
     return HttpResponseRedirect(reverse('index'))
 
 
+@require_POST
 def print_files(request):
-    if request.method == 'POST':
-        files = File.objects.all()
-        
-        errors = False
-        for fileObj in files:
-            output = file_printer.print_file(fileObj.name, fileObj.page_range,
-                                fileObj.pages, fileObj.color, fileObj.orientation)
-            err = output[1].decode()
-            if err != '':
-                errors = True
-                messages.error(request, err)
-            else:
-                messages.info(request, f"Printing {fileObj.name}")
-            
-            fileObj.delete()
+    files = list(File.objects.order_by('uploaded_at'))
+    if not files:
+        messages.info(request, 'No files are queued for printing.')
+        return HttpResponse(status=204)
 
-        if errors:
-            return HttpResponse(status=500)
-        else:
-            messages.success(request, 'Jobs completed')
-            return HttpResponse(status=204) # OK, Nothing to return
-    return HttpResponse(status=403) # !POST forbidden
+    errors = False
+    successful_jobs = 0
+
+    for file_obj in files:
+        try:
+            _stdout, stderr = file_printer.print_file(
+                file_obj.name,
+                file_obj.page_range,
+                file_obj.pages,
+                file_obj.color,
+                file_obj.orientation,
+            )
+        except Exception as exc:
+            errors = True
+            messages.error(request, f'Failed to print {file_obj.name}: {exc}')
+            continue
+
+        error_message = (stderr or b'').decode(errors='replace').strip()
+        if error_message:
+            errors = True
+            messages.error(request, error_message)
+            continue
+
+        messages.info(request, f'Printing {file_obj.name}')
+        file_obj.delete()
+        successful_jobs += 1
+
+    if errors:
+        return HttpResponse(status=500)
+
+    if successful_jobs:
+        messages.success(request, 'Jobs completed')
+    else:
+        messages.info(request, 'No files were printed.')
+    return HttpResponse(status=204)
 
 
 def edit_settings(request):
@@ -152,5 +216,5 @@ def edit_settings(request):
 
         messages.error(request, 'Please correct the errors below.')
 
-    context = { 'settings': app_settings, 'form': form }
+    context = {'settings': app_settings, 'form': form}
     return render(request, 'settings.html', context)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -254,6 +254,28 @@ select {
     padding: 0.8rem;
 }
 
+.file-delete-form {
+    display: inline-block;
+    margin-bottom: 0;
+}
+
+.folder-box-button {
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+}
+
+.folder-box-button:focus {
+    outline: none;
+}
+
+.folder-box-button:hover {
+    color: inherit;
+}
+
 .card-row {
     border-radius: 2px;
     padding: 3%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,14 +85,15 @@
                             <span class="fs-100"><i class="bi bi-clock"></i>&ensp;{{ file.uploaded_at }}</span>
                         </div>
                     </a>
-                    <a href="{% url 'delete_file' file.id %}" class="text-danger mb-2">
-                        <div class="folder-box-sm br-2 bg-white">
+                    <form method="post" action="{% url 'delete_file' file.id %}" class="file-delete-form">
+                        {% csrf_token %}
+                        <button type="submit" class="folder-box-sm br-2 bg-white folder-box-button text-danger mb-2">
                             Delete
                             <svg xmlns="http://www.w3.org/2000/svg" width="1.6em" height="1.6em" fill="currentColor" class="bi bi-x-circle-fill" viewBox="0 0 16 16" style="float: right;">
                                 <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"/>
                             </svg>
-                        </div>
-                    </a>
+                        </button>
+                    </form>
                 </div>
             {% endfor %}
             </div>


### PR DESCRIPTION
## Summary
- centralize uploads directory handling and improve file type detection
- harden file upload sanitization and add better validation and feedback for queue actions
- require POST for destructive actions and keep failed print jobs queued while reporting clearer status messages

## Testing
- python manage.py check
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68caab819edc8330b22e7320673c83f7