### PR TITLE
Configure WhiteNoise static file serving

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,14 @@ Setup
     source venv/bin/activate
     pip3 install -r requirements.txt
 
+| Collect the project's static assets so Gunicorn (via WhiteNoise) can serve
+| them directly. Re-run this command whenever you upgrade the application or
+| modify files under ``static/``:
+
+.. code:: bash
+
+    python manage.py collectstatic --no-input
+
 
 5) Database initialization (automatic)
 --------------------------------------
@@ -141,6 +149,14 @@ Setup
 
     source venv/bin/activate
     gunicorn --workers 2 --bind 0.0.0.0:8000 printer.wsgi:application
+
+| After Gunicorn starts, visit the site in a browser and make sure the UI is
+| styled. You can also request a known static asset directly to confirm
+| WhiteNoise is serving the collected files:
+
+.. code:: bash
+
+    curl -I http://<HOSTNAME>.local:8000/static/css/style.css
 
 
 | The repository includes a simple ``start.bash`` helper for Raspberry Pi
@@ -181,6 +197,14 @@ Setup
     echo "PRINTER_GUI_BIND_ADDRESS=192.168.1.4:8000" | sudo tee /etc/default/printerserver
     echo "PRINTER_GUI_GUNICORN_WORKERS=3" | sudo tee -a /etc/default/printerserver
     echo "PRINTER_GUI_ALLOWED_HOSTS=printer.example.com,printer.local" | sudo tee -a /etc/default/printerserver
+
+| Before starting or restarting the service, activate the virtualenv and run
+| ``collectstatic`` so WhiteNoise has the latest assets to serve:
+
+.. code:: bash
+
+    source /home/pi/printer-gui/venv/bin/activate
+    python /home/pi/printer-gui/manage.py collectstatic --no-input
 
 | Start and enable it once it matches your setup.
 

--- a/printer/settings.py
+++ b/printer/settings.py
@@ -155,6 +155,7 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'whitenoise.runserver_nostatic',
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
@@ -171,6 +172,7 @@ CRISPY_TEMPLATE_PACK = 'bootstrap5'  # For Crispy Forms
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -256,3 +258,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/printer/wsgi.py
+++ b/printer/wsgi.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise import WhiteNoise
 
 from .auto_migrate import ensure_migrations_applied
 
@@ -17,3 +18,4 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'printer.settings')
 
 application = get_wsgi_application()
 ensure_migrations_applied()
+application = WhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytz==2025.2
 sqlparse==0.5.3
 gunicorn==23.0.0
 zipp==3.23.0
+whitenoise==6.6.0


### PR DESCRIPTION
## Summary
- add WhiteNoise to the dependency list and configure Django to collect and serve static files in production
- enable WhiteNoise in settings and wrap the WSGI application so Gunicorn can serve `/static/`
- document the need to run `collectstatic` during deployment and how to verify static assets are being delivered

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'whitenoise' in the execution environment because pip cannot reach PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_68cad94701e4833096066208f17421cd