### PR TITLE
Automate static file collection on startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,9 +104,10 @@ Setup
     source venv/bin/activate
     pip3 install -r requirements.txt
 
-| Collect the project's static assets so Gunicorn (via WhiteNoise) can serve
-| them directly. Re-run this command whenever you upgrade the application or
-| modify files under ``static/``:
+| The included startup helpers run ``collectstatic`` before launching the
+| server so WhiteNoise always has the latest assets. If you start Django with
+| another command (for example, ``python manage.py runserver``), run the
+| following first to build the static asset manifest:
 
 .. code:: bash
 
@@ -163,8 +164,9 @@ Setup
 | deployments. Set the ``PRINTER_GUI_BIND_ADDRESS`` environment variable
 | to override the default bind address (``0.0.0.0:8000``) and
 | ``PRINTER_GUI_GUNICORN_WORKERS`` to control the number of worker
-| processes before using it, if desired. You can then launch the server
-| with:
+| processes before using it, if desired. The helper also refreshes the
+| static asset manifest automatically before Gunicorn starts. You can then
+| launch the server with:
 
 .. code:: bash
 
@@ -183,9 +185,9 @@ Setup
 | Assuming the server runs correctly, you may configure the
 | server to run automatically on startup as a systemd service.
 | On the Raspberry Pi, copy the 'printerserver.service' file
-| to '/etc/systemd/system/', review the ``User``, ``Group``, and
-| ``WorkingDirectory`` directives, and adjust them if your
-| environment differs from the defaults. The service reads
+| to '/etc/systemd/system/', review the ``User``, ``Group``,
+| ``WorkingDirectory``, and ``ExecStart`` directives, and adjust
+| them if your environment differs from the defaults. The service reads
 | optional overrides from ``/etc/default/printerserver``; you can
 | define ``PRINTER_GUI_BIND_ADDRESS`` there to change the bind
 | address, ``PRINTER_GUI_GUNICORN_WORKERS`` to tune the worker
@@ -198,13 +200,9 @@ Setup
     echo "PRINTER_GUI_GUNICORN_WORKERS=3" | sudo tee -a /etc/default/printerserver
     echo "PRINTER_GUI_ALLOWED_HOSTS=printer.example.com,printer.local" | sudo tee -a /etc/default/printerserver
 
-| Before starting or restarting the service, activate the virtualenv and run
-| ``collectstatic`` so WhiteNoise has the latest assets to serve:
-
-.. code:: bash
-
-    source /home/pi/printer-gui/venv/bin/activate
-    python /home/pi/printer-gui/manage.py collectstatic --no-input
+| The unit invokes ``start.bash`` so each restart refreshes the static assets
+| automatically before Gunicorn launches. If you customize the unit to call
+| Gunicorn directly, keep a ``collectstatic`` step in your workflow.
 
 | Start and enable it once it matches your setup.
 

--- a/printerserver.service
+++ b/printerserver.service
@@ -11,7 +11,7 @@ WorkingDirectory=/home/pi/printer-gui
 Environment=PRINTER_GUI_BIND_ADDRESS=0.0.0.0:8000
 Environment=PRINTER_GUI_GUNICORN_WORKERS=2
 EnvironmentFile=-/etc/default/printerserver
-ExecStart=/home/pi/printer-gui/venv/bin/gunicorn --bind ${PRINTER_GUI_BIND_ADDRESS} --workers ${PRINTER_GUI_GUNICORN_WORKERS} printer.wsgi:application
+ExecStart=/home/pi/printer-gui/start.bash
 Restart=on-failure
 RestartSec=5s
 

--- a/start.bash
+++ b/start.bash
@@ -10,6 +10,18 @@ if [[ -f "venv/bin/activate" ]]; then
     source "venv/bin/activate"
 fi
 
+PYTHON_BIN="python"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    if command -v python3 >/dev/null 2>&1; then
+        PYTHON_BIN="python3"
+    else
+        echo "Unable to locate a Python interpreter in PATH." >&2
+        exit 1
+    fi
+fi
+
+"$PYTHON_BIN" manage.py collectstatic --no-input
+
 BIND_ADDRESS="${PRINTER_GUI_BIND_ADDRESS:-0.0.0.0:8000}"
 WORKERS="${PRINTER_GUI_GUNICORN_WORKERS:-2}"
 


### PR DESCRIPTION
## Summary
- run `collectstatic` automatically from `start.bash` before launching Gunicorn
- update the sample systemd unit to invoke the helper script so restarts refresh static assets
- document the new behavior and note when manual `collectstatic` runs are still required

## Testing
- Unable to install Python requirements or run Django management commands in this environment (proxy blocks PyPI access)


------
https://chatgpt.com/codex/tasks/task_e_68cbb181a8248330a92c306d0cd082b2