### PR TITLE
Default to sole CUPS printer profile

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -82,20 +82,22 @@ def get_available_printer_profiles(current_selection: Optional[str] = None) -> L
 
 
 def _load_printer_profile():
+    available_printers = _collect_available_printers()
+
     app_settings = get_app_settings()
     if app_settings is None:
-        return DEFAULT_PRINTER_PROFILE
+        printer_name = None
+    else:
+        app_settings.refresh_from_db()
+        printer_name = sanitize_printer_name(app_settings.printer_profile)
 
-    app_settings.refresh_from_db()
-    printer_name = sanitize_printer_name(app_settings.printer_profile)
-    if printer_name is None:
-        return DEFAULT_PRINTER_PROFILE
+    if printer_name and printer_name in available_printers:
+        return printer_name
 
-    available_printers = set(_collect_available_printers())
-    if available_printers and printer_name not in available_printers:
-        return DEFAULT_PRINTER_PROFILE
+    if len(available_printers) == 1:
+        return available_printers[0]
 
-    return printer_name
+    return DEFAULT_PRINTER_PROFILE
 
 
 def _get_printer_profile():

--- a/printer/tests/test_printer_profile.py
+++ b/printer/tests/test_printer_profile.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from printer import file_printer
+
+
+@dataclass
+class _DummySettings:
+    printer_profile: Optional[str]
+
+    def refresh_from_db(self) -> None:  # pragma: no cover - behavior is trivial
+        """Mimic the ``Settings`` model refresh for the test helpers."""
+        # No-op for tests; the ``printer_profile`` attribute already holds the
+        # up-to-date value we want to exercise.
+        return None
+
+
+class PrinterProfileSelectionTests(SimpleTestCase):
+    def _load_profile_with(self, available: list[str], profile: Optional[str]):
+        dummy_settings = _DummySettings(printer_profile=profile)
+        with patch('printer.file_printer._collect_available_printers', return_value=available), patch(
+            'printer.file_printer.get_app_settings', return_value=dummy_settings
+        ):
+            return file_printer._load_printer_profile()
+
+    def test_single_available_printer_without_config_selects_printer(self) -> None:
+        profile = self._load_profile_with(['Solo_Printer'], file_printer.DEFAULT_PRINTER_PROFILE)
+
+        self.assertEqual(profile, 'Solo_Printer')
+
+    def test_single_available_printer_when_database_unavailable(self) -> None:
+        with patch('printer.file_printer._collect_available_printers', return_value=['Solo_Printer']), patch(
+            'printer.file_printer.get_app_settings', return_value=None
+        ):
+            profile = file_printer._load_printer_profile()
+
+        self.assertEqual(profile, 'Solo_Printer')
+
+    def test_multiple_printers_still_require_explicit_selection(self) -> None:
+        profile = self._load_profile_with(
+            ['Office_Printer', 'Lab_Printer'],
+            file_printer.DEFAULT_PRINTER_PROFILE,
+        )
+
+        self.assertEqual(profile, file_printer.DEFAULT_PRINTER_PROFILE)
+
+    def test_existing_selection_is_respected_when_available(self) -> None:
+        profile = self._load_profile_with(
+            ['Office_Printer', 'Lab_Printer'],
+            'Lab_Printer',
+        )
+
+        self.assertEqual(profile, 'Lab_Printer')


### PR DESCRIPTION
## Summary
- automatically fall back to the lone available CUPS printer when no profile has been configured
- add tests covering the printer profile selection logic

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cbbb263cd483309966401c136c878d