### PR TITLE
Add Docuvert conversion for unsupported uploads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ Changes
 
 - Capturing ``stderr`` from subprocesses to convey errors to the user.
 - Leveraging Django's Messages Framework to display statuses and exceptions.
-- Removed dependency on ``libreoffice``; only CUPS-supported formats are accepted.
+- Added Docuvert-powered conversion so common Office formats are rendered to
+  PDF automatically while files CUPS handles natively continue to bypass
+  conversion.
 - Re-designed UI for better look/feel. -- Improved mobile/overall experience.
 - Added a favicon to better distinguish the browser tab.
 - Added per-session print queues so simultaneous users do not consume each other's jobs.
@@ -26,11 +28,13 @@ Requirements
 - Python 3.10+ (required by Django 5.2) and the ``pip`` package installer on the SBC's OS.
 - Ability to install CUPS so the ``lp`` command is available to the application.
 - A network printer connected on the local network
+- Docuvert 1.1.2 to convert Office documents and OpenDocument files to PDF before printing
 
 
 Limitations
 ###########
-- Only pdf, ps, txt, jpg, jpeg, png, gif, and tiff files are supported.
+- Formats beyond pdf, ps, txt, jpg, jpeg, png, gif, tif/tiff, doc/docx,
+  ppt/pptx, xls/xlsx, odt/odp/ods, and rtf remain unsupported.
 - It seems that some printers may not respect page orientation chosen.
 
 
@@ -53,8 +57,8 @@ Setup
 2) Install system packages
 --------------------------
 | Install the CUPS packages so the ``lp`` command is available to Django.
-| LibreOffice and Java are no longer required because the app only accepts
-| formats handled directly by CUPS. On Debian/Ubuntu:
+| LibreOffice remains unnecessary; Docuvert (installed via ``pip``) now
+| handles Office/OpenDocument conversions. On Debian/Ubuntu:
 
 .. code:: bash
 

--- a/printer/conversion.py
+++ b/printer/conversion.py
@@ -1,0 +1,156 @@
+"""Utilities that convert uploaded files to PDF using Docuvert."""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+
+class ConversionError(RuntimeError):
+    """Raised when Docuvert cannot render an upload to PDF."""
+
+
+_DOCUVERT_CALLABLE: Optional[Callable[..., Any]] = None
+
+# Candidate callable names and keyword parameters supported by Docuvert. The
+# exact API differs across releases, so we probe common variations before
+# giving up.
+_CALLABLE_NAMES: Sequence[str] = (
+    "convert_to_pdf",
+    "convert_document",
+    "convert",
+    "convert_file",
+)
+_KEYWORD_VARIATIONS: Sequence[dict[str, Any]] = (
+    {},
+    {"output": None},
+    {"output_path": None},
+    {"target": None},
+    {"destination": None},
+    {"fmt": "pdf"},
+    {"format": "pdf"},
+)
+
+
+def _load_docuvert_callable() -> Callable[..., Any]:
+    try:
+        module = importlib.import_module("docuvert")
+    except ImportError as exc:  # pragma: no cover - exercised in production
+        raise ConversionError(
+            "Docuvert is not installed. Install docuvert==1.1.2 to enable "
+            "format conversion."
+        ) from exc
+
+    for attr in _CALLABLE_NAMES:
+        candidate = getattr(module, attr, None)
+        if callable(candidate):
+            return candidate
+
+    for attr in ("Docuvert", "Docuverter", "Client", "Converter"):
+        cls = getattr(module, attr, None)
+        if cls is None:
+            continue
+        try:
+            instance = cls()
+        except Exception as exc:  # pragma: no cover - depends on Docuvert API
+            raise ConversionError("Docuvert converter could not be instantiated.") from exc
+
+        for name in _CALLABLE_NAMES:
+            candidate = getattr(instance, name, None)
+            if callable(candidate):
+                return candidate
+
+    raise ConversionError(
+        "Docuvert 1.1.2 is available but does not expose a supported conversion "
+        "function."
+    )
+
+
+def _get_docuvert_callable() -> Callable[..., Any]:
+    global _DOCUVERT_CALLABLE
+
+    if _DOCUVERT_CALLABLE is None:
+        _DOCUVERT_CALLABLE = _load_docuvert_callable()
+    return _DOCUVERT_CALLABLE
+
+
+def _invoke_converter(
+    converter: Callable[..., Any], source: Path, target: Path
+) -> Any:
+    args = (str(source), str(target))
+    # Try a few call signatures so the integration tolerates minor API changes.
+    for kwargs in _KEYWORD_VARIATIONS:
+        prepared_kwargs = {}
+        for key, value in kwargs.items():
+            prepared_kwargs[key] = str(target) if value is None else value
+        try:
+            return converter(*args, **prepared_kwargs)
+        except TypeError:
+            continue
+    raise ConversionError(
+        "Docuvert conversion callable has an unsupported signature."
+    )
+
+
+def _normalize_result(result: Any, target: Path) -> None:
+    if isinstance(result, (bytes, bytearray)):
+        target.write_bytes(result)
+        return
+
+    candidate_paths: Iterable[Optional[Path]] = ()
+    if isinstance(result, (str, Path)):
+        candidate_paths = (Path(result),)
+    elif isinstance(result, dict):
+        candidate_paths = (
+            Path(value)
+            for key in ("output", "output_path", "path", "file", "file_path")
+            if (value := result.get(key))
+        )
+    elif isinstance(result, (list, tuple)) and result:
+        candidate_paths = (
+            Path(value)
+            for value in result
+            if isinstance(value, (str, Path))
+        )
+
+    for candidate in candidate_paths:
+        if candidate is None:
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+        except FileNotFoundError:
+            continue
+        if resolved == target.resolve():
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(resolved), str(target))
+        return
+
+    # If Docuvert wrote directly to the target path the above logic is a no-op.
+    if target.exists():
+        return
+
+    raise ConversionError("Docuvert did not produce a PDF output file.")
+
+
+def convert_document_to_pdf(source: Path, target: Path) -> None:
+    """Render ``source`` to ``target`` using Docuvert."""
+
+    if source == target:
+        raise ConversionError("Source and target paths must differ.")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    converter = _get_docuvert_callable()
+    try:
+        result = _invoke_converter(converter, source, target)
+    except ConversionError:
+        raise
+    except Exception as exc:  # pragma: no cover - depends on Docuvert's errors
+        raise ConversionError(f"Docuvert failed to convert the file: {exc}") from exc
+
+    _normalize_result(result, target)
+
+    if not target.exists():
+        raise ConversionError("Docuvert did not create the PDF output file.")

--- a/printer/forms.py
+++ b/printer/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from .models import *
 
 from .file_printer import get_available_printer_profiles
+from .upload_types import build_accept_attribute, describe_supported_extensions
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Row, Column
@@ -25,10 +26,10 @@ class FileUploadForm(forms.Form):
     file_upload = forms.FileField(
         label='Upload Document',
         required=True,
-        help_text='Only pdf, ps, txt, jpg, jpeg, png, gif, and tiff are supported',
+        help_text=f'Supported formats: {describe_supported_extensions()}',
         widget=forms.FileInput(attrs={
             'multiple': False,
-            'accept': 'application/pdf,application/postscript,text/plain,image/jpeg,image/png,image/gif,image/tiff'
+            'accept': build_accept_attribute()
         })
     )
 

--- a/printer/tests/test_upload_conversion.py
+++ b/printer/tests/test_upload_conversion.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from printer.models import File
+from printer.conversion import ConversionError
+
+
+class FileConversionTests(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls._temp_dir = Path(tempfile.mkdtemp())
+        cls._patchers = [
+            patch('printer.paths.UPLOADS_DIR', cls._temp_dir),
+            patch('printer.views.UPLOADS_DIR', cls._temp_dir),
+            patch('printer.models.UPLOADS_DIR', cls._temp_dir),
+        ]
+        for patcher in cls._patchers:
+            patcher.start()
+            cls.addClassCleanup(patcher.stop)
+
+        cls.addClassCleanup(lambda: shutil.rmtree(cls._temp_dir, ignore_errors=True))
+
+    def setUp(self) -> None:
+        super().setUp()
+        for entry in self._temp_dir.iterdir():
+            if entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink(missing_ok=True)
+
+    def test_docx_file_is_converted(self) -> None:
+        with patch('printer.views.convert_document_to_pdf') as convert_mock:
+            def _write_pdf(source: Path, target: Path) -> None:
+                target.write_bytes(b'%PDF-1.4')
+
+            convert_mock.side_effect = _write_pdf
+            response = self.client.post(
+                reverse('upload_file'),
+                {
+                    'file_upload': SimpleUploadedFile(
+                        'example.docx',
+                        b'fake-docx',
+                        content_type='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    )
+                },
+            )
+
+        self.assertEqual(response.status_code, 302)
+        stored_file = File.objects.get()
+        self.assertTrue(stored_file.name.endswith('.pdf'))
+        self.assertTrue((self._temp_dir / stored_file.name).exists())
+        self.assertFalse(list(self._temp_dir.glob('*.docx')))
+
+        convert_mock.assert_called_once()
+        source_arg, target_arg = convert_mock.call_args[0]
+        self.assertTrue(source_arg.name.endswith('.docx'))
+        self.assertTrue(target_arg.name.endswith('.pdf'))
+
+    def test_failed_conversion_reports_error(self) -> None:
+        with patch('printer.views.convert_document_to_pdf', side_effect=ConversionError('boom')):
+            response = self.client.post(
+                reverse('upload_file'),
+                {
+                    'file_upload': SimpleUploadedFile(
+                        'example.docx',
+                        b'fake-docx',
+                        content_type='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    )
+                },
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(File.objects.exists())
+        self.assertFalse(list(self._temp_dir.iterdir()))
+
+    def test_unsupported_extension_is_rejected(self) -> None:
+        response = self.client.post(
+            reverse('upload_file'),
+            {
+                'file_upload': SimpleUploadedFile(
+                    'example.exe',
+                    b'fake',
+                    content_type='application/octet-stream',
+                )
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(File.objects.exists())
+        self.assertFalse(list(self._temp_dir.iterdir()))

--- a/printer/upload_types.py
+++ b/printer/upload_types.py
@@ -1,0 +1,134 @@
+"""Supported upload formats and helpers for printer-gui."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+# File extensions CUPS can render without an intermediate conversion step.
+CUPS_NATIVE_EXTENSIONS: Set[str] = {
+    ".pdf",
+    ".ps",
+    ".txt",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".tif",
+    ".tiff",
+}
+
+# Formats that require Docuvert to render an intermediate PDF before printing.
+DOCUVERT_CONVERTIBLE_EXTENSIONS: Set[str] = {
+    ".doc",
+    ".docx",
+    ".ppt",
+    ".pptx",
+    ".xls",
+    ".xlsx",
+    ".odt",
+    ".odp",
+    ".ods",
+    ".rtf",
+}
+
+SUPPORTED_UPLOAD_EXTENSIONS: Set[str] = (
+    CUPS_NATIVE_EXTENSIONS | DOCUVERT_CONVERTIBLE_EXTENSIONS
+)
+
+# Display labels and MIME type hints for each supported extension. The order in
+# ``_DISPLAY_ORDER`` prioritizes the long-standing CUPS-native formats followed
+# by the Docuvert-powered conversions so related file types appear together in
+# the UI.
+_EXTENSION_DISPLAY_LABELS: Dict[str, str] = {
+    ".pdf": "pdf",
+    ".ps": "ps",
+    ".txt": "txt",
+    ".jpg": "jpg",
+    ".jpeg": "jpeg",
+    ".png": "png",
+    ".gif": "gif",
+    ".tif": "tif",
+    ".tiff": "tiff",
+    ".doc": "doc",
+    ".docx": "docx",
+    ".ppt": "ppt",
+    ".pptx": "pptx",
+    ".xls": "xls",
+    ".xlsx": "xlsx",
+    ".odt": "odt",
+    ".odp": "odp",
+    ".ods": "ods",
+    ".rtf": "rtf",
+}
+
+_EXTENSION_MIME_TYPES: Dict[str, str] = {
+    ".pdf": "application/pdf",
+    ".ps": "application/postscript",
+    ".txt": "text/plain",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".odt": "application/vnd.oasis.opendocument.text",
+    ".odp": "application/vnd.oasis.opendocument.presentation",
+    ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+    ".rtf": "application/rtf",
+}
+
+_DISPLAY_ORDER: List[str] = [
+    ".pdf",
+    ".ps",
+    ".txt",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".tif",
+    ".tiff",
+    ".doc",
+    ".docx",
+    ".ppt",
+    ".pptx",
+    ".xls",
+    ".xlsx",
+    ".odt",
+    ".odp",
+    ".ods",
+    ".rtf",
+]
+
+
+def describe_supported_extensions() -> str:
+    """Return a human-readable summary of supported upload extensions."""
+
+    labels: List[str] = []
+    added = set()
+    for extension in _DISPLAY_ORDER:
+        if extension not in SUPPORTED_UPLOAD_EXTENSIONS or extension in added:
+            continue
+        labels.append(_EXTENSION_DISPLAY_LABELS.get(extension, extension.lstrip(".")))
+        added.add(extension)
+
+    for extension in sorted(SUPPORTED_UPLOAD_EXTENSIONS - added):
+        labels.append(_EXTENSION_DISPLAY_LABELS.get(extension, extension.lstrip(".")))
+
+    return ", ".join(labels)
+
+
+def build_accept_attribute() -> str:
+    """Return a comma-separated list of MIME types for ``<input accept=...>``."""
+
+    accept_types = {
+        mime_type
+        for ext, mime_type in _EXTENSION_MIME_TYPES.items()
+        if ext in SUPPORTED_UPLOAD_EXTENSIONS
+    }
+    return ",".join(sorted(accept_types))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.9.1
 Django==5.2.6
 django-crispy-forms==2.4
 crispy-bootstrap5==2025.6
+docuvert==1.1.2
 pytz==2025.2
 sqlparse==0.5.3
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- add a Docuvert-backed conversion path so Office and OpenDocument uploads become PDFs before printing
- centralize supported upload metadata for validation and UI hints
- document the new dependency and add regression tests for conversion success and failure paths

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cbca0018b08330b96d490af3e5859e