### PR TITLE
Validate settings choices and surface failed print jobs

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -168,9 +168,24 @@ def print_pdf(filename, page_range, pages, color, orientation):
     command.extend(['-o', orientation_option, '-o', color_option, normalized_path])
 
     print_proc = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
-    output = print_proc.communicate()
+    stdout, stderr = print_proc.communicate()
 
-    return output
+    if print_proc.returncode != 0:
+        message_parts = []
+        for stream in (stderr, stdout):
+            if not stream:
+                continue
+            stripped = stream.strip()
+            if stripped:
+                message_parts.append(stripped)
+
+        message_parts.append(
+            f'Print command exited with status {print_proc.returncode}'.encode()
+        )
+        error_message = b"\n".join(message_parts)
+        return stdout, error_message
+
+    return stdout, stderr
 
 
 def _resolve_upload_file_path(filename: str) -> Optional[str]:

--- a/printer/forms.py
+++ b/printer/forms.py
@@ -46,17 +46,13 @@ class SettingsForm(forms.ModelForm):
     app_title = forms.CharField(
         label = 'App title',
     )
-    default_color = forms.CharField(
+    default_color = forms.ChoiceField(
         label='Color default',
-        widget=forms.Select(
-            choices=PrintOptions.COLOR_OPTIONS
-        )
+        choices=PrintOptions.COLOR_OPTIONS,
     )
-    default_orientation = forms.CharField(
+    default_orientation = forms.ChoiceField(
         label='Orientation default',
-        widget=forms.Select(
-            choices=PrintOptions.ORIENTATION_OPTIONS
-        )
+        choices=PrintOptions.ORIENTATION_OPTIONS,
     )
     printer_profile = forms.ChoiceField(
         label='Printer Profile',


### PR DESCRIPTION
## Summary
- validate the default color and orientation fields with ChoiceFields so tampered requests cannot persist invalid options
- treat non-zero `lp` exit codes as failures and surface the command status in the returned error message

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cc024bcfd483309e103c96720cb0b4