### PR TITLE
Surface printer status on home page

### DIFF
--- a/printer/tests/test_printer_status.py
+++ b/printer/tests/test_printer_status.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import subprocess as sp
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
+
+from printer import file_printer
+
+
+@dataclass
+class _DummySettings:
+    printer_profile: str
+
+    def refresh_from_db(self) -> None:  # pragma: no cover - trivial test helper
+        return None
+
+
+class PrinterStatusHelperTests(SimpleTestCase):
+    def test_helper_parses_idle_status(self) -> None:
+        dummy_settings = _DummySettings(printer_profile="Office_Printer")
+        lpstat_output = "printer Office_Printer is idle.  enabled since Tue 01 Jan 2021 10:00:00 AM"
+
+        with patch("printer.file_printer.get_app_settings", return_value=dummy_settings), patch(
+            "printer.file_printer.sp.run",
+            return_value=sp.CompletedProcess(
+                ["lpstat", "-p", "Office_Printer"],
+                0,
+                stdout=lpstat_output,
+                stderr="",
+            ),
+        ):
+            status = file_printer.get_printer_status()
+
+        self.assertEqual(status, "Idle")
+
+    def test_helper_returns_error_output_when_available(self) -> None:
+        lpstat_error = "lpstat: Printer not found"
+
+        with patch(
+            "printer.file_printer.sp.run",
+            return_value=sp.CompletedProcess(
+                ["lpstat", "-p", "Missing_Printer"],
+                1,
+                stdout="",
+                stderr=lpstat_error,
+            ),
+        ):
+            status = file_printer.get_printer_status("Missing_Printer")
+
+        self.assertEqual(status, lpstat_error)
+
+    def test_helper_handles_timeout(self) -> None:
+        with patch(
+            "printer.file_printer.sp.run",
+            side_effect=sp.TimeoutExpired(cmd=["lpstat", "-p", "Office_Printer"], timeout=5),
+        ):
+            status = file_printer.get_printer_status("Office_Printer")
+
+        self.assertEqual(status, "Printer status check timed out")
+
+
+class IndexViewPrinterStatusTests(TestCase):
+    def test_index_includes_printer_status(self) -> None:
+        with patch("printer.views.file_printer.get_printer_status", return_value="Printer status unavailable"):
+            response = self.client.get(reverse("index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["printer_status"], "Printer status unavailable")

--- a/printer/views.py
+++ b/printer/views.py
@@ -65,7 +65,8 @@ def index(request):
     _claim_legacy_files(session_key)
 
     files = File.objects.filter(session_key=session_key).order_by('-uploaded_at')
-    context = {'files': files}
+    printer_status = file_printer.get_printer_status()
+    context = {'files': files, 'printer_status': printer_status}
     return render(request, 'index.html', context)
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,11 @@
             <div class="d-flex justify-content-center">
                 <h1 class="text-light ff-sans-bolder ms-5 textshadow">{{ app_title }}</h1>
             </div>
+            <div class="d-flex justify-content-center mt-3">
+                <span class="badge bg-dark text-white fs-300 px-3 py-2 shadow-sm">
+                    Printer status: {{ printer_status }}
+                </span>
+            </div>
         </div>
        <div class="lightly-pad-container text-break bg-gradient-right-crimson-blue br-2 shadow" style="margin-bottom: 0px;">
             <h2 class="text-white text-center ff-sans-bolder">Uploaded Files</h2>


### PR DESCRIPTION
## Summary
- add a helper that queries lpstat with a timeout and returns a safe printer status string
- show the printer status on the index view and render it in the UI
- cover the status helper and view context with unit tests for success and failure paths

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cd05a63a408330a4265784d7bb65cd