### PR TITLE
Add printer diagnostics helper and status page

### DIFF
--- a/printer/tests/test_printer_diagnostics.py
+++ b/printer/tests/test_printer_diagnostics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+
+from printer import file_printer
+
+
+@dataclass
+class _DummySettings:
+    printer_profile: str
+
+    def refresh_from_db(self) -> None:  # pragma: no cover - trivial helper
+        return None
+
+
+class PrinterDiagnosticsHelperTests(SimpleTestCase):
+    def test_collects_state_and_supplies_from_pycups(self) -> None:
+        dummy_settings = _DummySettings(printer_profile="Office_Printer")
+        fake_connection = Mock()
+        fake_connection.getPrinterAttributes.return_value = {
+            "printer-state": 3,
+            "printer-state-message": "Ready to print.",
+            "marker-names": ["Black Toner", "Cyan Toner"],
+            "marker-levels": ["70", "50"],
+            "marker-colors": ["black", "cyan"],
+        }
+        fake_cups = SimpleNamespace(Connection=Mock(return_value=fake_connection))
+
+        with patch("printer.file_printer.get_app_settings", return_value=dummy_settings), patch(
+            "printer.file_printer.cups", fake_cups
+        ):
+            diagnostics = file_printer.get_printer_diagnostics()
+
+        self.assertEqual(diagnostics["printer"], "Office_Printer")
+        self.assertEqual(diagnostics["state"], "Idle")
+        self.assertEqual(diagnostics["state_message"], "Ready to print.")
+        self.assertEqual(
+            diagnostics["supplies"],
+            [
+                {"name": "Black Toner", "level": 70, "color": "black"},
+                {"name": "Cyan Toner", "level": 50, "color": "cyan"},
+            ],
+        )
+        self.assertIsNone(diagnostics["error"])
+
+    def test_returns_empty_supply_list_when_not_reported(self) -> None:
+        dummy_settings = _DummySettings(printer_profile="Office_Printer")
+        fake_connection = Mock()
+        fake_connection.getPrinterAttributes.return_value = {
+            "printer-state": "processing",
+            "printer-state-message": ["Job 123 is running"],
+        }
+        fake_cups = SimpleNamespace(Connection=Mock(return_value=fake_connection))
+
+        with patch("printer.file_printer.get_app_settings", return_value=dummy_settings), patch(
+            "printer.file_printer.cups", fake_cups
+        ):
+            diagnostics = file_printer.get_printer_diagnostics()
+
+        self.assertEqual(diagnostics["state"], "Processing")
+        self.assertEqual(diagnostics["supplies"], [])
+        self.assertIsNone(diagnostics["error"])
+
+    def test_handles_failure_when_no_attributes_available(self) -> None:
+        dummy_settings = _DummySettings(printer_profile="Office_Printer")
+        fake_cups = SimpleNamespace(Connection=Mock(side_effect=RuntimeError("pycups unavailable")))
+
+        with patch("printer.file_printer.get_app_settings", return_value=dummy_settings), patch(
+            "printer.file_printer.cups", fake_cups
+        ), patch("printer.file_printer._locate_ipptool_test_file", return_value="/tmp/ipptool"), patch(
+            "printer.file_printer.sp.run", side_effect=FileNotFoundError("ipptool")
+        ):
+            diagnostics = file_printer.get_printer_diagnostics()
+
+        self.assertEqual(diagnostics["printer"], "Office_Printer")
+        self.assertEqual(diagnostics["error"], "Printer status unavailable")
+        self.assertIsNone(diagnostics["state"])
+        self.assertEqual(diagnostics["supplies"], [])

--- a/printer/urls.py
+++ b/printer/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('submit_edit_file_form/', views.submit_edit_file_form, name='submit_edit_file_form'),
     path('delete_file/<int:file_id>/', views.delete_file, name='delete_file'),
     path('print_files/', views.print_files, name='print_files'),
+    path('status/', views.printer_status, name='printer_status'),
     path('settings', views.edit_settings, name='settings'),
 ]

--- a/printer/views.py
+++ b/printer/views.py
@@ -70,6 +70,13 @@ def index(request):
     return render(request, 'index.html', context)
 
 
+@never_cache
+def printer_status(request):
+    diagnostics = file_printer.get_printer_diagnostics()
+    context = {'diagnostics': diagnostics}
+    return render(request, 'printer_status.html', context)
+
+
 def upload_file(request):
     session_key = _ensure_session_key(request)
     app_settings = get_app_settings()

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,13 +21,20 @@
 <div class="p-3">
     <div class="container-md flow">
         <div id="splash-header" class="flow br-2 shadow">
-            <a href="{% url 'settings' %}" style="float: right;">
-                <button class="bttn-orange-sm me-1">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="2.5em" height="2.5em" fill="white" class="bi bi-gear-fill" viewBox="0 0 16 16">
-                        <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>
-                    </svg>
-                </button>
-            </a>
+            <div class="d-flex justify-content-end gap-2 me-2 mt-2">
+                <a href="{% url 'printer_status' %}" class="text-decoration-none">
+                    <button class="bttn-white px-3 py-2">
+                        <i class="bi bi-activity"></i>&ensp;Printer diagnostics
+                    </button>
+                </a>
+                <a href="{% url 'settings' %}" class="text-decoration-none">
+                    <button class="bttn-orange-sm me-1">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="2.5em" height="2.5em" fill="white" class="bi bi-gear-fill" viewBox="0 0 16 16">
+                            <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>
+                        </svg>
+                    </button>
+                </a>
+            </div>
             <div class="d-flex justify-content-center">
                 <h1 class="text-light ff-sans-bolder ms-5 textshadow">{{ app_title }}</h1>
             </div>

--- a/templates/printer_status.html
+++ b/templates/printer_status.html
@@ -1,0 +1,89 @@
+{% extends './base.html' %}
+
+{% block title %}Printer Diagnostics{% endblock title %}
+
+{% block content %}
+<div class="p-3">
+    <div class="container-md flow">
+        <div class="bg-gradient-right-crimson-blue br-2 mb-2 p-2">
+            <div class="bg-white br-2 lightly-pad-container shadow">
+                <h2 class="text-center">Printer Diagnostics</h2>
+            </div>
+            <div class="bg-white br-2 p-3 me-1 ms-1">
+                {% if diagnostics.printer %}
+                <p class="fs-5">Details for <strong>{{ diagnostics.printer }}</strong>.</p>
+                {% else %}
+                <div class="alert alert-warning" role="alert">
+                    No printer has been configured.
+                </div>
+                {% endif %}
+
+                {% if diagnostics.error %}
+                <div class="alert alert-warning" role="alert">
+                    {{ diagnostics.error }}
+                </div>
+                {% endif %}
+
+                <div class="mb-3">
+                    <h3 class="fs-4">Current status</h3>
+                    <dl class="row">
+                        <dt class="col-sm-4">State</dt>
+                        <dd class="col-sm-8">{{ diagnostics.state|default:"Not available" }}</dd>
+                        <dt class="col-sm-4">Message</dt>
+                        <dd class="col-sm-8">{{ diagnostics.state_message|default:"Not available" }}</dd>
+                    </dl>
+                </div>
+
+                <div class="mb-3">
+                    <h3 class="fs-4">Supplies</h3>
+                    {% if diagnostics.supplies %}
+                    <div class="table-responsive">
+                        <table class="table table-striped align-middle">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Name</th>
+                                    <th scope="col">Level</th>
+                                    <th scope="col">Color</th>
+                                    <th scope="col">Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for supply in diagnostics.supplies %}
+                                <tr>
+                                    <td>{{ supply.name|default:"—" }}</td>
+                                    <td>
+                                        {% if supply.level is not None %}
+                                            {{ supply.level }}
+                                        {% else %}
+                                            —
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ supply.color|default:"—" }}</td>
+                                    <td>{{ supply.state|default:"—" }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% elif not diagnostics.error %}
+                    <p class="text-muted mb-0">The printer did not report any supply information.</p>
+                    {% else %}
+                    <p class="text-muted mb-0">Supply levels are unavailable.</p>
+                    {% endif %}
+                </div>
+
+                <div class="d-flex justify-content-between flex-wrap gap-2">
+                    <a href="{% url 'index' %}" class="text-decoration-none">
+                        <button class="bttn-brand-blue">Back to home</button>
+                    </a>
+                    <a href="{% url 'printer_status' %}" class="text-decoration-none">
+                        <button class="bttn-white px-3 py-2">
+                            <i class="bi bi-arrow-clockwise"></i>&ensp;Refresh diagnostics
+                        </button>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Summary
- add a diagnostics helper that queries IPP attributes via pycups or ipptool and normalizes supply data
- surface printer diagnostics with a new Django view, template, and navigation link from the home page
- cover the helper with unit tests for normal, missing-data, and failure scenarios

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cd0a3c21f883309930763ae7edd8a0