### PR TITLE
Use env bash wrapper for service ExecStart

### DIFF
--- a/printergui.service
+++ b/printergui.service
@@ -11,7 +11,7 @@ WorkingDirectory=/home/pi/printer-gui
 Environment=PRINTER_GUI_BIND_ADDRESS=0.0.0.0:8000
 Environment=PRINTER_GUI_GUNICORN_WORKERS=2
 EnvironmentFile=-/etc/default/printergui
-ExecStart=/home/pi/printer-gui/printergui.bash
+ExecStart=/usr/bin/env bash /home/pi/printer-gui/printergui.bash
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
## Summary
- update the systemd unit to run the launcher script via `env bash`, eliminating the need for execute permissions on the script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d133033adc833097a2bc3af25f901f