### PR TITLE
Use generic plist sample for diagnostics parser

### DIFF
--- a/printer/file_printer.py
+++ b/printer/file_printer.py
@@ -715,6 +715,10 @@ def _parse_plist_attribute_value(value: Any) -> Optional[Any]:
                 return {name: nested_values[0]}
             return {name: nested_values}
 
+        collection = _parse_plist_collection(value)
+        if collection:
+            return collection
+
     return None
 
 
@@ -774,6 +778,14 @@ def _collect_plist_attributes(node: Any, attributes: Dict[str, Any]) -> None:
                 else:
                     _collect_plist_attributes(value, attributes)
             elif lower_key not in {"tag", "group-tag", "value-tag"}:
+                normalized_name = _normalize_string(key)
+                if normalized_name:
+                    parsed_values = _parse_plist_attribute_values(value)
+                    if parsed_values:
+                        _merge_ipptool_attribute_values(
+                            attributes, normalized_name, parsed_values
+                        )
+                        continue
                 _collect_plist_attributes(value, attributes)
 
     elif isinstance(node, list):


### PR DESCRIPTION
## Summary
- replace the HP Officejet ipptool plist fixture in diagnostics tests with a generic inline sample that keeps coverage printer-agnostic
- teach the plist parser to read attribute dictionaries and nested collections emitted by ipptool

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d286794ba883308f570ff7c0d4ae88